### PR TITLE
Fix runtime NameError

### DIFF
--- a/kernel.py
+++ b/kernel.py
@@ -14,7 +14,7 @@ LOCAL_DUMP_PATH = "window_dump.xml"
 
 client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 
-def run_adb_command(command: List[str]):
+def run_adb_command(command: list[str]):
     """Executes a shell command via ADB."""
     result = subprocess.run([ADB_PATH] + command, capture_output=True, text=True)
     if result.stderr and "error" in result.stderr.lower():


### PR DESCRIPTION
fix: replace invalid List annotation with builtin list

Failed Build Logs:
<details>
  <summary>View build error log</summary>

```log
Traceback (most recent call last): File "/home/rana/android-action-kernel/kernel.py", line 17, in <module> 
def run_adb_command(command: List[str]): 
            ^^^^ 
NameError: name 'List' is not defined. Did you mean: 'list'?